### PR TITLE
logstash: normalize LAYER and LAYERS fields

### DIFF
--- a/logstash/pipelines/logstash.conf
+++ b/logstash/pipelines/logstash.conf
@@ -25,6 +25,10 @@ filter {
         lowercase => [ "Error"]
         uppercase => [ "Service"]
         rename => [ "Service", "SERVICE"]
+        rename => { "layer" => "LAYER" }
+        rename => { "Layer" => "LAYER" }
+        rename => { "layers" => "LAYERS" }
+        rename => { "Layers" => "LAYERS" }
         convert => { "RequestId" => "integer"}
         convert => { "WIDTH" => "integer"}
         convert => { "HEIGHT" => "integer"}


### PR DESCRIPTION
This can be useful since OGC protocols allow to use any casing for field names.
Quite a fragile solution though; only a couple of common cases are handled.